### PR TITLE
Fix Windows compatibility and add option to set query driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore VS Code folder
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Unfortunately, there seems to be no plan within LLVM to accelerate the standalon
 
 ```
 usage: clangd-tidy [-h] [-p COMPILE_COMMANDS_DIR] [-j JOBS] [-o OUTPUT]
+                   [-j JOBS] [-o OUTPUT]
                    [--clangd-executable CLANGD_EXECUTABLE]
                    [--allow-extensions ALLOW_EXTENSIONS]
                    [--fail-on-severity SEVERITY] [--tqdm] [--github]
@@ -69,6 +70,8 @@ options:
                         the path is invalid, clangd will look in the current
                         directory and parent paths of each source file.
                         [default: build]
+  -q QUERY_DRIVER, --query-driver QUERY_DRIVER
+                        Query driver to pass to clangd, if any.
   -j JOBS, --jobs JOBS  Number of async workers used by clangd. Background
                         index also uses this many workers. [default: 1]
   -o OUTPUT, --output OUTPUT

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Unfortunately, there seems to be no plan within LLVM to accelerate the standalon
 ## Usage
 
 ```
-usage: clangd-tidy [-h] [-p COMPILE_COMMANDS_DIR] [-j JOBS] [-o OUTPUT]
-                   [-j JOBS] [-o OUTPUT]
+usage: clangd-tidy [-h] [-V] [-p COMPILE_COMMANDS_DIR]
+                   [--query-driver QUERY_DRIVER] [-j JOBS] [-o OUTPUT]
                    [--clangd-executable CLANGD_EXECUTABLE]
                    [--allow-extensions ALLOW_EXTENSIONS]
                    [--fail-on-severity SEVERITY] [--tqdm] [--github]
-                   [--git-root GIT_ROOT] [-c] [--context CONTEXT]
-                   [--color {auto,always,never}] [-v]
+                   [--gitlab [JSON]] [-q] [--git-root GIT_ROOT] [-c]
+                   [--context CONTEXT] [--color {auto,always,never}] [-v]
                    filename [filename ...]
 
 Run clangd with clang-tidy and output diagnostics. This aims to serve as a
@@ -70,7 +70,7 @@ options:
                         the path is invalid, clangd will look in the current
                         directory and parent paths of each source file.
                         [default: build]
-  -q QUERY_DRIVER, --query-driver QUERY_DRIVER
+  --query-driver QUERY_DRIVER
                         Query driver to pass to clangd, if any.
   -j JOBS, --jobs JOBS  Number of async workers used by clangd. Background
                         index also uses this many workers. [default: 1]
@@ -83,10 +83,13 @@ options:
                         [default: c,h,cpp,cc,cxx,hpp,hh,hxx,cu,cuh]
   --fail-on-severity SEVERITY
                         On which severity of diagnostics this program should
-                        exit with a non-zero status. Candidates: error, warn,
-                        info, hint. [default: hint]
+                        exit with a non-zero status. Candidates: never, error,
+                        warn, info, hint. [default: hint]
   --tqdm                Show a progress bar (tqdm required).
   --github              Append workflow commands for GitHub Actions to output.
+  --gitlab [JSON]       Create code quality report for GitLab CI/CD. If a value
+                        is provided, it will be used as the filename.
+  -q, --quiet           Do not pretty print warnings to output.
   --git-root GIT_ROOT   Root directory of the git repository. Only works with
                         --github. [default: current directory]
   -c, --compact         Print compact diagnostics (legacy).

--- a/clangd-tidy
+++ b/clangd-tidy
@@ -222,9 +222,11 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    ext_filter = FileExtensionFilter(set(map(str.strip, args.allow_extensions)))
+    ext_filter = FileExtensionFilter(
+        set(map(str.strip, args.allow_extensions)))
     # Resolve all paths and make sure only unique paths are kept
-    files = set([pathlib.Path(file).resolve() for file in filter(ext_filter, args.filename)])
+    files = set([pathlib.Path(file).resolve()
+                for file in filter(ext_filter, args.filename)])
     for file in files:
         if not os.path.isfile(file):
             print(f"File not found: {file}", file=sys.stderr)
@@ -250,12 +252,14 @@ if __name__ == "__main__":
         stderr=subprocess.PIPE,
     )
     assert p.stderr is not None
-    read_pipe = ReadPipe(p.stderr, args.verbose and sys.stderr or open(os.devnull, "w"))
+    read_pipe = ReadPipe(
+        p.stderr, args.verbose and sys.stderr or open(os.devnull, "w"))
     read_pipe.start()
 
     # Kill clangd subprocess on SIGINT
     pbar = None  # use to close progress bar if it exists
-    signal.signal(signal.SIGINT, lambda sig, _: kill_child_process(sig, _, [p], pbar))
+    signal.signal(signal.SIGINT, lambda sig,
+                  _: kill_child_process(sig, _, [p], pbar))
 
     collector = DiagnosticCollector()
 
@@ -274,7 +278,8 @@ if __name__ == "__main__":
     root_uri = _file_uri(root_path)
     workspace_folders = [{"name": "foo", "uri": root_uri}]
 
-    lsp_client.initialize(p.pid, None, root_uri, None, None, "off", workspace_folders)
+    lsp_client.initialize(p.pid, None, root_uri, None,
+                          None, "off", workspace_folders)
     lsp_client.initialized()
 
     for file in files:
@@ -290,6 +295,8 @@ if __name__ == "__main__":
             )
             args.tqdm = False
 
+    is_aborted_due_to_timeout = False
+    previous_len = -1
     if args.tqdm:
         from tqdm import tqdm
 
@@ -297,22 +304,35 @@ if __name__ == "__main__":
             collector.cond.acquire()
             while len(collector.diagnostics) < len(files):
                 pbar.update(len(collector.diagnostics) - pbar.n)
-		# TODO: Handle timeout
-                collector.cond.wait(60)
+                if len(collector.diagnostics) <= previous_len:
+                    print(
+                        "No new diagnostics. Something is probably stuck.",
+                        file=sys.stderr,
+                    )
+                    is_aborted_due_to_timeout = True
+                    break
+                previous_len = len(collector.diagnostics)
+                collector.cond.wait(300)
             pbar.update(len(collector.diagnostics) - pbar.n)
             collector.cond.release()
     else:
         collector.cond.acquire()
         while len(collector.diagnostics) < len(files):
-            # TODO: Handle timeout
-            collector.cond.wait(60)
+            if len(collector.diagnostics) <= previous_len:
+                print(
+                    "No new diagnostics. Something is probably stuck.",
+                    file=sys.stderr,
+                )
+                is_aborted_due_to_timeout = True
+                break
+            previous_len = len(collector.diagnostics)
+            collector.cond.wait(300)
         collector.cond.release()
 
     lsp_client.shutdown()
     lsp_client.exit()
-    lsp_endpoint.join()
+    lsp_endpoint.join(60)
 
-    # TODO Handle timeout
     p.wait(60)
     if read_pipe.is_alive():
         read_pipe.join(60)
@@ -339,5 +359,7 @@ if __name__ == "__main__":
             ),
             file=args.output,
         )
+    if is_aborted_due_to_timeout:
+        exit(2)
     if collector.check_failed(args.fail_on_severity):
         exit(1)

--- a/clangd-tidy
+++ b/clangd-tidy
@@ -324,6 +324,11 @@ if __name__ == "__main__":
                     file=sys.stderr,
                 )
                 is_aborted_due_to_timeout = True
+                # Print missing files
+                transformed_diag_files = set(map(pathlib.Path, collector.diagnostics.keys()))
+                for file in files:
+                    if file not in transformed_diag_files:
+                        print(f"File not found in diagnostics: {file}", file=sys.stderr)
                 break
             previous_len = len(collector.diagnostics)
             collector.cond.wait(300)

--- a/clangd-tidy
+++ b/clangd-tidy
@@ -71,11 +71,11 @@ def _is_output_supports_color(output: TextIO):
 
 class DiagnosticCollector:
     SEVERITY_INT = {
+        "never": 0,
         "error": 1,
         "warn": 2,
         "info": 3,
         "hint": 4,
-        "never": 5,
     }
 
     def __init__(self):

--- a/clangd-tidy
+++ b/clangd-tidy
@@ -223,7 +223,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     ext_filter = FileExtensionFilter(set(map(str.strip, args.allow_extensions)))
-    files = list(filter(ext_filter, args.filename))
+    # Resolve all paths and make sure only unique paths are kept
+    files = set([pathlib.Path(file).resolve() for file in filter(ext_filter, args.filename)])
     for file in files:
         if not os.path.isfile(file):
             print(f"File not found: {file}", file=sys.stderr)
@@ -296,21 +297,25 @@ if __name__ == "__main__":
             collector.cond.acquire()
             while len(collector.diagnostics) < len(files):
                 pbar.update(len(collector.diagnostics) - pbar.n)
-                collector.cond.wait()
+		# TODO: Handle timeout
+                collector.cond.wait(60)
             pbar.update(len(collector.diagnostics) - pbar.n)
             collector.cond.release()
     else:
         collector.cond.acquire()
         while len(collector.diagnostics) < len(files):
-            collector.cond.wait()
+            # TODO: Handle timeout
+            collector.cond.wait(60)
         collector.cond.release()
 
     lsp_client.shutdown()
     lsp_client.exit()
     lsp_endpoint.join()
-    p.wait()
+
+    # TODO Handle timeout
+    p.wait(60)
     if read_pipe.is_alive():
-        read_pipe.join()
+        read_pipe.join(60)
 
     formatter = (
         diagnostic_formatter.FancyDiagnosticFormatter(

--- a/clangd-tidy
+++ b/clangd-tidy
@@ -331,11 +331,14 @@ if __name__ == "__main__":
 
     lsp_client.shutdown()
     lsp_client.exit()
-    lsp_endpoint.join(60)
 
-    p.wait(60)
-    if read_pipe.is_alive():
-        read_pipe.join(60)
+    try:
+        lsp_endpoint.join(60)
+        p.wait(60)
+        if read_pipe.is_alive():
+            read_pipe.join(60)
+    except subprocess.TimeoutExpired:
+        print("Failed to terminate clangd process.", file=sys.stderr)
 
     formatter = (
         diagnostic_formatter.FancyDiagnosticFormatter(

--- a/clangd-tidy
+++ b/clangd-tidy
@@ -75,6 +75,7 @@ class DiagnosticCollector:
         "warn": 2,
         "info": 3,
         "hint": 4,
+        "never": 5,
     }
 
     def __init__(self):
@@ -226,7 +227,7 @@ if __name__ == "__main__":
     for file in files:
         if not os.path.isfile(file):
             print(f"File not found: {file}", file=sys.stderr)
-            sys.exit(1)
+            exit(1)
 
     clangd_command = [
         f"{args.clangd_executable}",

--- a/clangd-tidy
+++ b/clangd-tidy
@@ -6,6 +6,8 @@ import signal
 import subprocess
 import sys
 import threading
+import pathlib
+from urllib.parse import urlparse, unquote
 from typing import IO, Set, TextIO
 
 import diagnostic_formatter
@@ -52,13 +54,15 @@ class FileExtensionFilter:
 
 
 def _file_uri(path: str):
-    return "file://" + path
+    return pathlib.Path(path).as_uri()
 
 
 def _uri_file(uri: str):
-    if not uri.startswith("file://"):
-        raise ValueError("Not a file URI: " + uri)
-    return uri[7:]
+    path = unquote(urlparse(uri).path)
+    if path.startswith('/') and ':' in path[1:3]:
+        # Probably a WIndows path that ended up getting an erroneous leading slash
+        path = path[1:]
+    return path
 
 
 def _is_output_supports_color(output: TextIO):
@@ -80,7 +84,7 @@ class DiagnosticCollector:
 
     def handle_publish_diagnostics(self, args):
         file = _uri_file(args["uri"])
-        if file not in self.requested_files:
+        if pathlib.Path(file) not in self.requested_files:
             return
         self.cond.acquire()
         self.diagnostics[file] = args["diagnostics"]
@@ -88,7 +92,7 @@ class DiagnosticCollector:
         self.cond.release()
 
     def request_diagnostics(self, lsp_client: LspClient, file_path: str):
-        file_path = os.path.abspath(file_path)
+        file_path = pathlib.Path(file_path).resolve()
         languageId = LANGUAGE_IDENTIFIER.CPP
         version = 1
         text = open(file_path, "r").read()
@@ -138,6 +142,12 @@ if __name__ == "__main__":
         "--compile-commands-dir",
         default="build",
         help="Specify a path to look for compile_commands.json. If the path is invalid, clangd will look in the current directory and parent paths of each source file. [default: build]",
+    )
+    parser.add_argument(
+        "-q",
+        "--query-driver",
+        type=str,
+        help="Query driver to pass to clangd, if any."
     )
     parser.add_argument(
         "-j",
@@ -228,6 +238,9 @@ if __name__ == "__main__":
         "--offset-encoding=utf-16",
     ]
 
+    if args.query_driver:
+        clangd_command.append(f"--query-driver={args.query_driver}")
+
     p = subprocess.Popen(
         clangd_command,
         stdin=subprocess.PIPE,
@@ -294,7 +307,7 @@ if __name__ == "__main__":
     lsp_client.shutdown()
     lsp_client.exit()
     lsp_endpoint.join()
-    os.wait()
+    p.wait()
     if read_pipe.is_alive():
         read_pipe.join()
 

--- a/clangd-tidy
+++ b/clangd-tidy
@@ -145,7 +145,6 @@ if __name__ == "__main__":
         help="Specify a path to look for compile_commands.json. If the path is invalid, clangd will look in the current directory and parent paths of each source file. [default: build]",
     )
     parser.add_argument(
-        "-q",
         "--query-driver",
         type=str,
         help="Query driver to pass to clangd, if any."
@@ -188,6 +187,21 @@ if __name__ == "__main__":
         "--github",
         action="store_true",
         help="Append workflow commands for GitHub Actions to output.",
+    )
+    parser.add_argument(
+        "--gitlab",
+        metavar="JSON",
+        const='gl-code-quality-report.json',
+        default=None,
+        nargs='?',
+        help="Create code quality report for GitLab CI/CD. If a value is provided, it will be used as the filename.",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="Do not pretty print warnings to output.",
     )
     parser.add_argument(
         "--git-root",
@@ -325,10 +339,12 @@ if __name__ == "__main__":
                 )
                 is_aborted_due_to_timeout = True
                 # Print missing files
-                transformed_diag_files = set(map(pathlib.Path, collector.diagnostics.keys()))
+                transformed_diag_files = set(
+                    map(pathlib.Path, collector.diagnostics.keys()))
                 for file in files:
                     if file not in transformed_diag_files:
-                        print(f"File not found in diagnostics: {file}", file=sys.stderr)
+                        print(
+                            f"File not found in diagnostics: {file}", file=sys.stderr)
                 break
             previous_len = len(collector.diagnostics)
             collector.cond.wait(300)
@@ -345,19 +361,20 @@ if __name__ == "__main__":
     except subprocess.TimeoutExpired:
         print("Failed to terminate clangd process.", file=sys.stderr)
 
-    formatter = (
-        diagnostic_formatter.FancyDiagnosticFormatter(
-            extra_context=args.context,
-            enable_color=(
-                _is_output_supports_color(args.output)
-                if args.color == "auto"
-                else args.color == "always"
-            ),
+    if not args.quiet:
+        formatter = (
+            diagnostic_formatter.FancyDiagnosticFormatter(
+                extra_context=args.context,
+                enable_color=(
+                    _is_output_supports_color(args.output)
+                    if args.color == "auto"
+                    else args.color == "always"
+                ),
+            )
+            if not args.compact
+            else diagnostic_formatter.CompactDiagnosticFormatter()
         )
-        if not args.compact
-        else diagnostic_formatter.CompactDiagnosticFormatter()
-    )
-    print(collector.format_diagnostics(formatter), file=args.output)
+        print(collector.format_diagnostics(formatter), file=args.output)
     if args.github:
         print(
             collector.format_diagnostics(
@@ -366,6 +383,13 @@ if __name__ == "__main__":
                 )
             ),
             file=args.output,
+        )
+    if args.gitlab is not None:
+        collector.format_diagnostics(
+            diagnostic_formatter.GitLabCodeQualityDiagnosticFormatter(
+                args.gitlab,
+                args.git_root
+            )
         )
     if is_aborted_due_to_timeout:
         exit(2)

--- a/clangd-tidy
+++ b/clangd-tidy
@@ -254,10 +254,16 @@ if __name__ == "__main__":
         "--pch-storage=memory",
         "--enable-config",
         "--offset-encoding=utf-16",
+        # TODO: Remove these options as they were for debugging why we do not get full analysis on GitLab CI pipeline!?
+        "--log=info",
     ]
 
     if args.query_driver:
         clangd_command.append(f"--query-driver={args.query_driver}")
+
+    # TODO: Remove the following lines as it was for debugging why we do not get full analysis on GitLab CI pipeline!?
+    command_str = " ".join(clangd_command)
+    print(f"Starting clangd with command: {command_str}", file=sys.stderr)
 
     p = subprocess.Popen(
         clangd_command,
@@ -292,6 +298,8 @@ if __name__ == "__main__":
     root_uri = _file_uri(root_path)
     workspace_folders = [{"name": "foo", "uri": root_uri}]
 
+    # TODO: Remove the following line as it was for debugging why we do not get full analysis on GitLab CI pipeline!?
+    print(f"Init LSP client with root URI: {root_uri}", file=sys.stderr)
     lsp_client.initialize(p.pid, None, root_uri, None,
                           None, "off", workspace_folders)
     lsp_client.initialized()
@@ -347,7 +355,13 @@ if __name__ == "__main__":
                             f"File not found in diagnostics: {file}", file=sys.stderr)
                 break
             previous_len = len(collector.diagnostics)
+            
+            # TODO: Remove the following line as it was for debugging why we do not get full analysis on GitLab CI pipeline!?
+            print(f"Got diagnostics for {previous_len} out of {len(files)} files.", file=sys.stderr)
+            sys.stderr.flush()
             collector.cond.wait(300)
+        # TODO: Remove the following line as it was for debugging why we do not get full analysis on GitLab CI pipeline!?
+        print(f"Got all diagnostics for {len(files)} files.", file=sys.stderr)
         collector.cond.release()
 
     lsp_client.shutdown()


### PR DESCRIPTION
I made some changes to actually make this work for me on my Windows 11 machine, while cross-compiling using `arm-none-eabi-g++`.

For this I needed to:
* Fix the file path handling, as the hardcoded transformations where not compatible with Windows.
* Replace the `os.wait()` call, as this is not available on Windows.
* Add a `--query-driver` option to pass a query-driver to clangd (so it can actually work with the cross-compiler).
* Add a `never` option for `fail-on-severity`, so that I can integrate it in CI to collect warnings without failing the build.

After that it seems to run. I did stil see some other areas for improvement (e.g. if an exception is thrown, the program now hangs forever, as the subprocess is not killed). But I decided to not dive too deep into these now.

Hopefully someone else can verify if this still works as expected on *nix systems.