### PR TITLE
feat: add ability to run clangd-tidy over source control diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ pip install clangd-tidy
 usage: clangd-tidy [-h] [-p COMPILE_COMMANDS_DIR] [-j JOBS] [-o OUTPUT]
                    [--clangd-executable CLANGD_EXECUTABLE]
                    [--allow-extensions ALLOW_EXTENSIONS]
-                   [--fail-on-severity SEVERITY] [--tqdm] [--github]
-                   [--git-root GIT_ROOT] [-c] [--context CONTEXT]
-                   [--color {auto,always,never}] [-v]
-                   filename [filename ...]
+                   [--fail-on-severity SEVERITY] [--line-filter LINE_FILTER]
+                   [--tqdm] [--github] [--git-root GIT_ROOT] 
+                   [-c] [--context CONTEXT] [--color {auto,always,never}]
+                   [-v] filename [filename ...]
 
 Run clangd with clang-tidy and output diagnostics. This aims to serve as a
 faster alternative to clang-tidy.
@@ -88,6 +88,8 @@ options:
                         On which severity of diagnostics this program should
                         exit with a non-zero status. Candidates: error, warn,
                         info, hint. [default: hint]
+  --line-filter LINE_FILTER
+                        A JSON with a list of files and line ranges that will act as a filter for diagnostics. Compatible with clang-tidy --line-filter parameter format.                        
   --tqdm                Show a progress bar (tqdm required).
   --github              Append workflow commands for GitHub Actions to output.
   --git-root GIT_ROOT   Root directory of the git repository. Only works with

--- a/clangd_tidy/__init__.py
+++ b/clangd_tidy/__init__.py
@@ -1,4 +1,5 @@
+from .clangd_tidy_diff_cli import clang_tidy_diff
 from .main_cli import main_cli
 from .version import __version__
 
-__all__ = ["main_cli", "__version__"]
+__all__ = ["main_cli", "clang_tidy_diff", "__version__"]

--- a/clangd_tidy/clangd_tidy_diff_cli.py
+++ b/clangd_tidy/clangd_tidy_diff_cli.py
@@ -1,0 +1,91 @@
+"""
+Receives a diff on stdin and runs clangd-tidy only on the changed lines.
+This is useful to slowly onboard a codebase to linting or to find regressions.
+Inspired by clang-tidy-diff.py from the LLVM project.
+
+Example usage with git:
+    git diff -U0 HEAD^^..HEAD | clangd-tidy-diff -p my/build
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+from .version import __version__
+
+ADDED_FILE_NAME_REGEX = re.compile(r'^\+\+\+ "?(?P<prefix>.*?/)(?P<file>[^\s"]*)')
+ADDED_LINES_REGEX = re.compile(r"^@@.*\+(?P<line>\d+)(,(?P<count>\d+))?")
+
+
+def clang_tidy_diff():
+    parser = argparse.ArgumentParser(
+        description="Runs clangd-tidy against modified files,"
+        " and returns diagnostics only on changed lines."
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    parser.add_argument(
+        "-p",
+        "--compile-commands-dir",
+        help="Specify a path to look for compile_commands.json. If the path is invalid, clangd-tidy will look in the current directory and parent paths of each source file.",
+    )
+    parser.add_argument(
+        "--pass-arg",
+        action="append",
+        help="Pass this argument to clangd-tidy (can be used multiple times)",
+    )
+    args = parser.parse_args()
+
+    last_file = None
+    lines_per_file = {}
+    for line in sys.stdin:
+        m = re.search(ADDED_FILE_NAME_REGEX, line)
+        if m:
+            last_file = m.group("file")
+
+        if last_file is None:
+            continue
+
+        m = re.search(ADDED_LINES_REGEX, line)
+        if m is None:
+            continue
+
+        start_line = int(m.group("line"))
+        line_count = 1
+        if m.group("count") is not None:
+            line_count = int(m.group("count"))
+        if line_count == 0:
+            continue
+
+        end_line = start_line + line_count - 1
+        lines_per_file.setdefault(last_file, []).append([start_line, end_line])
+
+    if len(lines_per_file) == 0:
+        print("No relevant changes found.")
+        sys.exit(0)
+
+    filters = []
+    for file, lines in lines_per_file.items():
+        filters.append({"name": file, "lines": lines})
+
+    filters_json = json.dumps(filters)
+    command = ["clangd-tidy", "--line-filter", filters_json]
+
+    if args.compile_commands_dir:
+        command.extend(["--compile-commands-dir", args.compile_commands_dir])
+
+    if args.pass_arg:
+        command.extend(args.pass_arg)
+
+    files = list(lines_per_file.keys())
+    command.append("--")
+    command.extend(files)
+
+    sys.exit(subprocess.run(command).returncode)
+
+
+if __name__ == "__main__":
+    clang_tidy_diff()

--- a/clangd_tidy/lines_filter.py
+++ b/clangd_tidy/lines_filter.py
@@ -1,0 +1,98 @@
+import argparse
+import json
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FileLineFilter:
+    """
+    Filters diagnostics in line ranges of a specific file
+    """
+
+    file_name: str
+    """
+    File name to filter, can be any postfix of a filtered file path
+    """
+    line_ranges: list[tuple[int, int]] = field(default_factory=list)
+    """
+    List of inclusive line ranges where diagnostics will be emitted
+    """
+
+    def allows(self, file_path: str, start_line: int, end_line: int) -> bool:
+        if not file_path.endswith(self.file_name):
+            return False
+
+        if len(self.line_ranges) == 0:
+            return True
+
+        for allowed_lines in self.line_ranges:
+            if self.interval_intersect(allowed_lines, (start_line, end_line)):
+                return True
+
+        return False
+
+    @staticmethod
+    def interval_intersect(
+        interval1: tuple[int, int], interval2: tuple[int, int]
+    ) -> bool:
+        a, b = interval1
+        c, d = interval2
+
+        return max(a, c) <= min(b, d)
+
+
+@dataclass
+class LineFilter:
+    """
+    Filters diagnostics by line ranges.
+    This is meant to be compatible with clang-tidy --line-filter syntax.
+    """
+
+    file_line_filters: list[FileLineFilter] = field(default_factory=list)
+
+    def allows(self, file_path: str, start_line: int, end_line: int) -> bool:
+        if len(self.file_line_filters) == 0:
+            return True
+
+        for file_line_filter in self.file_line_filters:
+            if file_line_filter.allows(file_path, start_line, end_line):
+                return True
+
+        return False
+
+    def filter_diagnostics(self, file: str, diagnostics: list[dict]) -> list[dict]:
+        def allow_diagnostic(diagnostic: dict) -> bool:
+            return self.allows(
+                file,
+                diagnostic["range"]["start"]["line"] + 1,
+                diagnostic["range"]["end"]["line"] + 1,
+            )
+
+        filtered = filter(allow_diagnostic, diagnostics)
+        return list(filtered)
+
+    @staticmethod
+    def parse_line_filter(s: str) -> "LineFilter":
+        try:
+            line_filter = json.loads(s)
+        except json.JSONDecodeError as e:
+            raise argparse.ArgumentTypeError(
+                f"Invalid line filter JSON string: {e=} [{s=}]"
+            )
+
+        filter_list = [LineFilter._parse_file_line_filter(f) for f in line_filter]
+        return LineFilter(filter_list)
+
+    @staticmethod
+    def _parse_file_line_filter(single_filter: dict) -> FileLineFilter:
+        ranges = []
+        lines = single_filter.get("lines", [])
+        for line_range in lines:
+            assert len(line_range) == 2, (
+                "Line ranges should be an inclusive range"
+                f" of the form [start, end] {line_range=} "
+            )
+            ranges.append(tuple(line_range))
+
+        name = single_filter["name"]
+        return FileLineFilter(name, ranges)

--- a/clangd_tidy/main_cli.py
+++ b/clangd_tidy/main_cli.py
@@ -8,14 +8,13 @@ import sys
 import threading
 from typing import IO, Set, TextIO
 
-from clangd_tidy.lines_filter import LineFilter
-
 from .diagnostic_formatter import (
     CompactDiagnosticFormatter,
     DiagnosticFormatter,
     FancyDiagnosticFormatter,
     GithubActionWorkflowCommandDiagnosticFormatter,
 )
+from .lines_filter import LineFilter
 from .pylspclient.json_rpc_endpoint import JsonRpcEndpoint
 from .pylspclient.lsp_client import LspClient
 from .pylspclient.lsp_endpoint import LspEndpoint
@@ -84,7 +83,6 @@ class DiagnosticCollector:
     def __init__(self, line_filter: LineFilter):
         self.diagnostics = {}
         self.requested_files = set()
-        self.line_filter = dict()
         self.cond = threading.Condition()
         self.line_filter = line_filter
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 
 [project.scripts]
 clangd-tidy = "clangd_tidy:main_cli"
+clangd-tidy-diff = "clangd_tidy:clang_tidy_diff"
 
 [project.urls]
 "Homepage" = "https://github.com/lljbash/clangd-tidy"


### PR DESCRIPTION
1. Adds a `--line-filter` argument support similar to clang tidy. This allows filtering of diagnostics on per file and per line range basis
2. Add `clangd-tidy-diff` a CLI command similar to `clang-tidy-diff`, which runs clangd-tidy on all files changed in a unified diff and filters the diagnostics to only contain those from changed lines. This allows easier onboarding for large existing codebases. 