### PR TITLE
feat: add terminal hyperlinks to diagnostic check name [1.1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Unfortunately, there seems to be no plan within LLVM to accelerate the standalon
       # Require clangd-17
       MissingIncludes: Strict
     ```
+- Hyperlinks on diagnostic check names in supported terminals.
 - Refer to [Usage](#usage) for more features.
 
 **Cons:**
@@ -121,6 +122,8 @@ Special thanks to [@yeger00](https://github.com/yeger00) for his [pylspclient](h
 
 A big shoutout to [clangd](https://clangd.llvm.org/) and [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) for their great work!
 
-Claps to [@ArchieAtkinson](https://github.com/ArchieAtkinson) for his artistic flair in the fancy diagnostic formatter.
+Claps to
+- [@ArchieAtkinson](https://github.com/ArchieAtkinson) for his artistic flair in the fancy diagnostic formatter.
+- [@jmpfar](https://github.com/jmpfar) for his contribution to hyperlink support.
 
 Contributions are welcome! Feel free to open an issue or a pull request.

--- a/clangd_tidy/lsp/messages.py
+++ b/clangd_tidy/lsp/messages.py
@@ -117,12 +117,17 @@ class DiagnosticSeverity(Enum):
 
 
 @define
+class CodeDescription:
+    href: str
+
+
+@define
 class Diagnostic:
     range: Range
     message: str
     severity: Optional[DiagnosticSeverity] = None
     code: Any = None
-    codeDescription: Any = None
+    codeDescription: CodeDescription = None
     source: Optional[str] = None
     tags: Optional[List[Any]] = None
     relatedInformation: Optional[List[Any]] = None

--- a/clangd_tidy/lsp/messages.py
+++ b/clangd_tidy/lsp/messages.py
@@ -127,7 +127,7 @@ class Diagnostic:
     message: str
     severity: Optional[DiagnosticSeverity] = None
     code: Any = None
-    codeDescription: CodeDescription = None
+    codeDescription: Optional[CodeDescription] = None
     source: Optional[str] = None
     tags: Optional[List[Any]] = None
     relatedInformation: Optional[List[Any]] = None


### PR DESCRIPTION
See https://iterm2.com/feature-reporting/Hyperlinks_in_Terminal_Emulators.html for information about terminal hyperlinks. This is supported by multiple terminals and makes it easier to find out more information about a failing check.

This is the equivalent of PR #9 rebased on branch 1.1 (closes #9)