### PR TITLE
perf: memory use: send `didClose` on completed files

### DIFF
--- a/clangd_tidy/lsp/clangd.py
+++ b/clangd_tidy/lsp/clangd.py
@@ -94,14 +94,7 @@ class ClangdAsync:
         assert path.is_file()
         await self._client.notify(
             NotificationMethod.DID_CLOSE,
-            DidCloseTextDocumentParams(
-                TextDocumentItem(
-                    uri=path.as_uri(),
-                    languageId=LanguageId.CPP,
-                    version=1,
-                    text=path.read_text(),
-                )
-            ),
+            DidCloseTextDocumentParams(TextDocumentIdentifier(uri=path.as_uri())),
         )
 
     async def formatting(self, path: pathlib.Path) -> None:

--- a/clangd_tidy/lsp/clangd.py
+++ b/clangd_tidy/lsp/clangd.py
@@ -6,6 +6,7 @@ from typing import Union
 
 from .client import ClientAsync, RequestResponsePair
 from .messages import (
+    DidCloseTextDocumentParams,
     DidOpenTextDocumentParams,
     DocumentFormattingParams,
     InitializeParams,
@@ -80,6 +81,20 @@ class ClangdAsync:
         await self._client.notify(
             NotificationMethod.DID_OPEN,
             DidOpenTextDocumentParams(
+                TextDocumentItem(
+                    uri=path.as_uri(),
+                    languageId=LanguageId.CPP,
+                    version=1,
+                    text=path.read_text(),
+                )
+            ),
+        )
+
+    async def did_close(self, path: pathlib.Path) -> None:
+        assert path.is_file()
+        await self._client.notify(
+            NotificationMethod.DID_CLOSE,
+            DidCloseTextDocumentParams(
                 TextDocumentItem(
                     uri=path.as_uri(),
                     languageId=LanguageId.CPP,

--- a/clangd_tidy/lsp/messages.py
+++ b/clangd_tidy/lsp/messages.py
@@ -23,6 +23,7 @@ class NotificationMethod(Enum):
     INITIALIZED = "initialized"
     EXIT = "exit"
     DID_OPEN = "textDocument/didOpen"
+    DID_CLOSE = "textDocument/didClose"
     PUBLISH_DIAGNOSTICS = "textDocument/publishDiagnostics"
 
 
@@ -88,6 +89,11 @@ class TextDocumentItem:
 
 @define
 class DidOpenTextDocumentParams(Params):
+    textDocument: TextDocumentItem
+
+
+@define
+class DidCloseTextDocumentParams(Params):
     textDocument: TextDocumentItem
 
 

--- a/clangd_tidy/lsp/messages.py
+++ b/clangd_tidy/lsp/messages.py
@@ -88,13 +88,18 @@ class TextDocumentItem:
 
 
 @define
+class TextDocumentIdentifier:
+    uri: str
+
+
+@define
 class DidOpenTextDocumentParams(Params):
     textDocument: TextDocumentItem
 
 
 @define
 class DidCloseTextDocumentParams(Params):
-    textDocument: TextDocumentItem
+    textDocument: TextDocumentIdentifier
 
 
 @define
@@ -152,11 +157,6 @@ class PublishDiagnosticsParams(Params):
 @define
 class WorkDoneProgressParams(Params):
     workDoneToken: Any = None
-
-
-@define
-class TextDocumentIdentifier:
-    uri: str
 
 
 @define(kw_only=True)

--- a/clangd_tidy/main_cli.py
+++ b/clangd_tidy/main_cli.py
@@ -83,8 +83,8 @@ class ClangdRunner:
             await self._sem.acquire()
             await self._clangd.did_open(file)
             if self._run_format:
-                await self._sem.acquire()
                 await self._clangd.formatting(file)
+
 
     async def _collect_diagnostics(self) -> DiagnosticCollection:
         diagnostics: DiagnosticCollection = {}
@@ -106,9 +106,7 @@ class ClangdRunner:
                         # Note: didClose triggers a new, empty publishDiagnostics
                         # "file not in diagnostics" required to persist the first diagnostic, from the open file
                         if file in self._files and file not in diagnostics:
-                            if file in formatting_diagnostics:
-                                # All diagnostics received
-                                await self._clangd.did_close(file)
+                            await self._clangd.did_close(file)
                             diagnostics[file] = params.diagnostics
                             tqdm.update(pbar)  # type: ignore
                             self._sem.release()
@@ -119,24 +117,19 @@ class ClangdRunner:
                         resp.request.params, DocumentFormattingParams
                     )
                     file = _uri_to_path(params.textDocument.uri)
-                    if file not in formatting_diagnostics:
-                        if file in diagnostics:
-                            # All diagnostics received
-                            await self._clangd.did_close(file)
-                        formatting_diagnostics[file] = (
-                            [
-                                Diagnostic(
-                                    range=Range(
-                                        start=Position(0, 0), end=Position(0, 0)
-                                    ),
-                                    message="File does not conform to the formatting rules (run `clang-format` to fix)",
-                                    source="clang-format",
-                                )
-                            ]
-                            if resp.response.result
-                            else []
-                        )
-                        self._sem.release()
+                    formatting_diagnostics[file] = (
+                        [
+                            Diagnostic(
+                                range=Range(
+                                    start=Position(0, 0), end=Position(0, 0)
+                                ),
+                                message="File does not conform to the formatting rules (run `clang-format` to fix)",
+                                source="clang-format",
+                            )
+                        ]
+                        if resp.response.result
+                        else []
+                    )
         return {
             file: formatting_diagnostics[file] + diagnostics[file]
             for file in self._files

--- a/clangd_tidy/main_cli.py
+++ b/clangd_tidy/main_cli.py
@@ -103,7 +103,11 @@ class ClangdRunner:
                     if resp.method == NotificationMethod.PUBLISH_DIAGNOSTICS:
                         params = cattrs.structure(resp.params, PublishDiagnosticsParams)
                         file = _uri_to_path(params.uri)
-                        if file in self._files:
+                        # Note: didClose triggers a new, empty publishDiagnostics
+                        # "file not in diagnostics" required to persist the first diagnostic, from the open file
+                        if file in self._files and file not in diagnostics:
+                            if file in formatting_diagnostics:
+                                await self._clangd.did_close(file) # all diagnostics received
                             diagnostics[file] = params.diagnostics
                             tqdm.update(pbar)  # type: ignore
                             self._sem.release()
@@ -114,18 +118,21 @@ class ClangdRunner:
                         resp.request.params, DocumentFormattingParams
                     )
                     file = _uri_to_path(params.textDocument.uri)
-                    formatting_diagnostics[file] = (
-                        [
-                            Diagnostic(
-                                range=Range(start=Position(0, 0), end=Position(0, 0)),
-                                message="File does not conform to the formatting rules (run `clang-format` to fix)",
-                                source="clang-format",
-                            )
-                        ]
-                        if resp.response.result
-                        else []
-                    )
-                    self._sem.release()
+                    if file not in formatting_diagnostics:
+                        if file in diagnostics:
+                            await self._clangd.did_close(file) # all diagnostics received
+                        formatting_diagnostics[file] = (
+                            [
+                                Diagnostic(
+                                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                                    message="File does not conform to the formatting rules (run `clang-format` to fix)",
+                                    source="clang-format",
+                                )
+                            ]
+                            if resp.response.result
+                            else []
+                        )
+                        self._sem.release()
         return {
             file: formatting_diagnostics[file] + diagnostics[file]
             for file in self._files

--- a/clangd_tidy/main_cli.py
+++ b/clangd_tidy/main_cli.py
@@ -85,7 +85,6 @@ class ClangdRunner:
             if self._run_format:
                 await self._clangd.formatting(file)
 
-
     async def _collect_diagnostics(self) -> DiagnosticCollection:
         diagnostics: DiagnosticCollection = {}
         formatting_diagnostics: DiagnosticCollection = (
@@ -120,9 +119,7 @@ class ClangdRunner:
                     formatting_diagnostics[file] = (
                         [
                             Diagnostic(
-                                range=Range(
-                                    start=Position(0, 0), end=Position(0, 0)
-                                ),
+                                range=Range(start=Position(0, 0), end=Position(0, 0)),
                                 message="File does not conform to the formatting rules (run `clang-format` to fix)",
                                 source="clang-format",
                             )

--- a/clangd_tidy/main_cli.py
+++ b/clangd_tidy/main_cli.py
@@ -107,7 +107,8 @@ class ClangdRunner:
                         # "file not in diagnostics" required to persist the first diagnostic, from the open file
                         if file in self._files and file not in diagnostics:
                             if file in formatting_diagnostics:
-                                await self._clangd.did_close(file) # all diagnostics received
+                                # All diagnostics received
+                                await self._clangd.did_close(file)
                             diagnostics[file] = params.diagnostics
                             tqdm.update(pbar)  # type: ignore
                             self._sem.release()
@@ -120,11 +121,14 @@ class ClangdRunner:
                     file = _uri_to_path(params.textDocument.uri)
                     if file not in formatting_diagnostics:
                         if file in diagnostics:
-                            await self._clangd.did_close(file) # all diagnostics received
+                            # All diagnostics received
+                            await self._clangd.did_close(file)
                         formatting_diagnostics[file] = (
                             [
                                 Diagnostic(
-                                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                                    range=Range(
+                                        start=Position(0, 0), end=Position(0, 0)
+                                    ),
                                     message="File does not conform to the formatting rules (run `clang-format` to fix)",
                                     source="clang-format",
                                 )


### PR DESCRIPTION
When porting a large codebase to `clangd-tidy`, we noticed `clangd` accumulates much more memory than plain `clang-tidy`, especially when running on many files.

This PR improves it by closing files whose diagnostics have been received, instead of leaving all files open. Peak RSS on my codebase fell from 47.0GB to 24.1GB.