### PR TITLE
feat: add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: clangd-tidy
+  name: clangd-tidy
+  entry: clangd-tidy
+  description: Runs clangd-tidy against passed files
+  language: python
+  types_or: [c++, c, objective-c]
+  require_serial: true
+  additional_dependencies: [clangd, clang-tidy]


### PR DESCRIPTION
Allows clangd-tidy to be utilized as a pre-commit hook. Because pre-commit/prek operate in isolated environments, this specifies clangd and clang-tidy as dependencies explicitly; people calling the hook can provide specific versions if desired